### PR TITLE
Generate test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,39 @@
 
 This is a demo project to show converting proofs from tendermint/iavl into the format
 specified in confio/proofs and validating that they still work.
+
+## Library usage
+
+It exposes a top-level function `func ConvertExistenceProof(p *iavl.RangeProof, key, value []byte) (*proofs.ExistenceProof, error)`
+that can convert from iavl range proofs into confio/proof protobuf objects.
+
+It currently only works for existence proofs, eg. RangeProofs that prove the existence of *exactly one* item.
+
+We plan to soon support non-existence proofs.
+
+Generalized range proofs are lower in priority, as they are just an optimization of the
+two basic proof types, and don't provide any additional capabilities.
+
+## CLI usage
+
+We also expose a simple script to generate test data for the confio proofs package.
+
+```shell
+go install ./cmd/testgen-iavl
+testgen-iavl
+```
+
+Will output some json data, from a randomly generated merkle tree each time.
+
+```json
+{
+  "existence": "0a146f65436a684273735a34567543774b567a435963121e76616c75655f666f725f6f65436a684273735a34567543774b567a4359631a0d0a0b0801180120012a030002021a2d122b08011204020402201a2120d307032505383dee34ea9eadf7649c31d1ce294b6d62b273d804da478ac161da1a2d122b08011204040802201a2120306b7d51213bd93bac17c5ee3d727ec666300370b19fd55cc13d7341dc589a991a2b12290801122508160220857103d59863ac55d1f34008a681f837c01975a223c0f54883a05a446d49c7c6201a2b1229080112250a2202204498eb5c93e40934bc8bad9626f19e333c1c0be4541b9098f139585c3471bae2201a2d122b080112040e6c02201a212022648db12dbf830485cc41435ecfe37bcac26c6c305ac4304f649977ddc339d51a2c122a0801122610c60102204e0b7996a7104f5b1ac1a2caa0704c4b63f60112e0e13763b2ba03f40a54e845201a2c122a08011226129003022017858e28e0563f7252eaca19acfc1c3828c892e635f76f971b3fbdc9bbd2742e20",
+  "root": "cea07656c77e8655521f4c904730cf4649242b8e482be786b2b220a15150d5f0"
+}
+```
+
+`"root"` is the hex-encoded root hash of the merkle tree
+
+`"existence"` is the hex-encoding of the protobuf binary encoding of a `proofs.ExistenceProof` object. This contains a (key, value) pair,
+along with all steps to reach the root hash. This provides a non-trivial test case, to ensure client in multiple languages can verify the
+protobuf proofs we generate from the iavl tree  

--- a/cmd/testgen-iavl/main.go
+++ b/cmd/testgen-iavl/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	iavlproofs "github.com/confio/proofs-iavl"
+)
+
+/**
+testgen-iavl will generate a json struct on stdout (meant to be saved to file for testdata).
+this will be an auto-generated existence proof in the form:
+
+{
+	"root": "<hex encoded root hash of tree>",
+	"existence": "<hex encoded protobuf marshaling of an existence proof>"
+}
+**/
+
+func main() {
+	proof, err := iavlproofs.GenerateRangeProof(200)
+	if err != nil {
+		fmt.Printf("Error: generate proof: %+v\n", err)
+		os.Exit(1)
+	}
+
+	converted, err := iavlproofs.ConvertExistenceProof(proof.Proof, proof.Key, proof.Value)
+	if err != nil {
+		fmt.Printf("Error: convert proof: %+v\n", err)
+		os.Exit(1)
+	}
+
+	binary, err := converted.Marshal()
+	if err != nil {
+		fmt.Printf("Error: protobuf marshal: %+v\n", err)
+		os.Exit(1)
+	}
+
+	res := map[string]interface{}{
+		"root":      hex.EncodeToString(proof.RootHash),
+		"existence": hex.EncodeToString(binary),
+	}
+	out, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		fmt.Printf("Error: json encoding: %+v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(out))
+}

--- a/convert.go
+++ b/convert.go
@@ -75,8 +75,6 @@ func convertInnerOps(path iavl.PathToLeaf) []*proofs.ProofOp {
 			suffix = append(suffix, path[i].Right...)
 		}
 
-		path[i].Hash([]byte{0x80, 0x08})
-
 		op := &proofs.InnerOp{
 			Hash:   proofs.HashOp_SHA256,
 			Prefix: prefix,

--- a/convert_test.go
+++ b/convert_test.go
@@ -2,21 +2,16 @@ package iavlproofs
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
-
-	"github.com/tendermint/iavl"
-	cmn "github.com/tendermint/tendermint/libs/common"
-	"github.com/tendermint/tendermint/libs/db"
 )
 
 func TestConvertProof(t *testing.T) {
-	proof, err := generateRangeProof(200)
+	proof, err := GenerateRangeProof(200)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	converted, err := ConvertExistenceProof(proof.proof, proof.key, proof.value)
+	converted, err := ConvertExistenceProof(proof.Proof, proof.Key, proof.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,55 +21,7 @@ func TestConvertProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(calc, proof.rootHash) {
-		t.Errorf("Calculated: %X\nExpected:   %X", calc, proof.rootHash)
+	if !bytes.Equal(calc, proof.RootHash) {
+		t.Errorf("Calculated: %X\nExpected:   %X", calc, proof.RootHash)
 	}
-}
-
-type provenValue struct {
-	key      []byte
-	value    []byte
-	proof    *iavl.RangeProof
-	rootHash []byte
-}
-
-// generateRangeProof makes a tree of size and returns a range proof for one random element
-//
-// returns a range proof and the root hash of the tree
-func generateRangeProof(size int) (*provenValue, error) {
-	tree := iavl.NewMutableTree(db.NewMemDB(), 0)
-
-	// insert lots of info and store the bytes
-	allkeys := make([][]byte, size)
-	for i := 0; i < size; i++ {
-		key := cmn.RandStr(20)
-		value := "value_for_" + key
-		tree.Set([]byte(key), []byte(value))
-		allkeys[i] = []byte(key)
-	}
-
-	key := allkeys[0]
-	// key := []byte{0xca, 0xfe}
-	// val := []byte{0xde, 0xad, 0xbe, 0xef}
-	// tree.Set(key, val)
-
-	value, proof, err := tree.GetWithProof(key)
-	if err != nil {
-		return nil, err
-	}
-	if value == nil {
-		return nil, fmt.Errorf("GetWithProof returned nil value")
-	}
-	if len(proof.Leaves) != 1 {
-		return nil, fmt.Errorf("GetWithProof returned %d leaves", len(proof.Leaves))
-	}
-	root := tree.WorkingHash()
-
-	res := &provenValue{
-		key:      key,
-		value:    value,
-		proof:    proof,
-		rootHash: root,
-	}
-	return res, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,12 @@ require (
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/google/pprof v0.0.0-20190404155422-f8f10df84213 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tendermint/go-amino v0.14.1 // indirect
 	github.com/tendermint/iavl v0.12.2
 	github.com/tendermint/tendermint v0.31.4
+	github.com/tendermint/tmlibs v0.9.0
+	golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/pprof v0.0.0-20190404155422-f8f10df84213 h1:y77GPNuZbqlt3/OjKA9yysnnxxqW+XwLaGY3ol9Mgmc=
+github.com/google/pprof v0.0.0-20190404155422-f8f10df84213/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -41,6 +43,10 @@ github.com/tendermint/iavl v0.12.2/go.mod h1:EoKMMv++tDOL5qKKVnoIqtVPshRrEPeJ0Ws
 github.com/tendermint/tendermint v0.30.2/go.mod h1:ymcPyWblXCplCPQjbOYbrF1fWnpslATMVqiGgWbZrlc=
 github.com/tendermint/tendermint v0.31.4 h1:F/vZ/fMHZJriAkDLjf9ZrReJQsuELiTmJLqigmbE5NU=
 github.com/tendermint/tendermint v0.31.4/go.mod h1:ymcPyWblXCplCPQjbOYbrF1fWnpslATMVqiGgWbZrlc=
+github.com/tendermint/tmlibs v0.9.0 h1:3aU/D2v3aecqpODOuBXCfi950bHTefD5Pps5X3XuJDc=
+github.com/tendermint/tmlibs v0.9.0/go.mod h1:4L0tAKpLTioy14VnmbXYTLIJN0pCMiehxDMdN6zZfM8=
+golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c h1:Rx/HTKi09myZ25t1SOlDHmHOy/mKxNAcu0hP1oPX9qM=
+golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20181126093934-9eb0be3963ea/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -51,3 +57,4 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,57 @@
+package iavlproofs
+
+import (
+	"fmt"
+
+	"github.com/tendermint/iavl"
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/db"
+)
+
+type IavlResult struct {
+	Key      []byte
+	Value    []byte
+	Proof    *iavl.RangeProof
+	RootHash []byte
+}
+
+// GenerateRangeProof makes a tree of size and returns a range proof for one random element
+//
+// returns a range proof and the root hash of the tree
+func GenerateRangeProof(size int) (*IavlResult, error) {
+	tree := iavl.NewMutableTree(db.NewMemDB(), 0)
+
+	// insert lots of info and store the bytes
+	allkeys := make([][]byte, size)
+	for i := 0; i < size; i++ {
+		key := cmn.RandStr(20)
+		value := "value_for_" + key
+		tree.Set([]byte(key), []byte(value))
+		allkeys[i] = []byte(key)
+	}
+
+	key := allkeys[0]
+	// key := []byte{0xca, 0xfe}
+	// val := []byte{0xde, 0xad, 0xbe, 0xef}
+	// tree.Set(key, val)
+
+	value, proof, err := tree.GetWithProof(key)
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return nil, fmt.Errorf("GetWithProof returned nil value")
+	}
+	if len(proof.Leaves) != 1 {
+		return nil, fmt.Errorf("GetWithProof returned %d leaves", len(proof.Leaves))
+	}
+	root := tree.WorkingHash()
+
+	res := &IavlResult{
+		Key:      key,
+		Value:    value,
+		Proof:    proof,
+		RootHash: root,
+	}
+	return res, nil
+}


### PR DESCRIPTION
Add a script `cmd/testgen-iavl` that produces json files with a hex-encoded proof data along with the proper root hash.

This produces random, non-trivial test cases that can be used by client implementations as test vectors to verify compatibility