### PR TITLE
Update deps and spec to newest ics23

### DIFF
--- a/create.go
+++ b/create.go
@@ -20,6 +20,7 @@ var IavlSpec = &ics23.ProofSpec{
 		MinPrefixLength: 4,
 		MaxPrefixLength: 12,
 		ChildSize:       33, // (with length byte)
+		Hash:            ics23.HashOp_SHA256,
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/confio/ics23-iavl
 go 1.14
 
 require (
-	github.com/confio/ics23/go v0.0.0-20200316202129-754fba6c5fdb // update-proto-spec
-	github.com/tendermint/iavl v0.13.1
+	github.com/confio/ics23/go v0.0.0-20200323120010-7d9a00f0a2fa // update-proto-spec
+	github.com/tendermint/iavl v0.13.2
 	github.com/tendermint/tendermint v0.33.2
 	github.com/tendermint/tm-db v0.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/confio/ics23-iavl
 go 1.14
 
 require (
-	github.com/confio/ics23/go v0.0.0-20190827163738-67deea06493e // v0.5.0
+	github.com/confio/ics23/go v0.0.0-20200316202129-754fba6c5fdb // update-proto-spec
 	github.com/tendermint/iavl v0.13.1
 	github.com/tendermint/tendermint v0.33.2
 	github.com/tendermint/tm-db v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/confio/ics23/go v0.0.0-20200316200307-492bd3c6f3f6 h1:WyZuWel0DTa7seG
 github.com/confio/ics23/go v0.0.0-20200316200307-492bd3c6f3f6/go.mod h1:W1I3XC8d9N8OTu/ct5VJ84ylcOunZwMXsWkd27nvVts=
 github.com/confio/ics23/go v0.0.0-20200316202129-754fba6c5fdb h1:o8vRNhuwVbBqBgx2aXnGmss25I5d3pNFpQbjcU1wPL4=
 github.com/confio/ics23/go v0.0.0-20200316202129-754fba6c5fdb/go.mod h1:W1I3XC8d9N8OTu/ct5VJ84ylcOunZwMXsWkd27nvVts=
+github.com/confio/ics23/go v0.0.0-20200323120010-7d9a00f0a2fa h1:aqH90CygjbiuKqIBoVChyc2PwymJ5K5SrOvpvtNIOuk=
+github.com/confio/ics23/go v0.0.0-20200323120010-7d9a00f0a2fa/go.mod h1:W1I3XC8d9N8OTu/ct5VJ84ylcOunZwMXsWkd27nvVts=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -336,6 +338,8 @@ github.com/tendermint/go-amino v0.14.1 h1:o2WudxNfdLNBwMyl2dqOJxiro5rfrEaU0Ugs6o
 github.com/tendermint/go-amino v0.14.1/go.mod h1:i/UKE5Uocn+argJJBb12qTZsCDBcAYMbR92AaJVmKso=
 github.com/tendermint/iavl v0.13.1 h1:KWg3NVqOZLJFCLKpUJjUprdWAgIYdC9GDJLN8PBmKbI=
 github.com/tendermint/iavl v0.13.1/go.mod h1:vE1u0XAGXYjHykd4BLp8p/yivrw2PF1TuoljBcsQoGA=
+github.com/tendermint/iavl v0.13.2 h1:O1m08/Ciy53l9IYmf75uIRVvrNsfjEbre8u/yCu/oqk=
+github.com/tendermint/iavl v0.13.2/go.mod h1:vE1u0XAGXYjHykd4BLp8p/yivrw2PF1TuoljBcsQoGA=
 github.com/tendermint/tendermint v0.33.2 h1:NzvRMTuXJxqSsFed2J7uHmMU5N1CVzSpfi3nCc882KY=
 github.com/tendermint/tendermint v0.33.2/go.mod h1:25DqB7YvV1tN3tHsjWoc2vFtlwICfrub9XO6UBO+4xk=
 github.com/tendermint/tm-db v0.4.1/go.mod h1:JsJ6qzYkCGiGwm5GHl/H5GLI9XLb6qZX7PRe425dHAY=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,10 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/confio/ics23/go v0.0.0-20190827163738-67deea06493e h1:yhvB+Wg9rCnUQvdAx65iIrpqRjh3VGFCFdl779IvRjY=
 github.com/confio/ics23/go v0.0.0-20190827163738-67deea06493e/go.mod h1:rWOCtymU+x3jM2Uib0aszytidui3pfpffvjCfNwATaE=
+github.com/confio/ics23/go v0.0.0-20200316200307-492bd3c6f3f6 h1:WyZuWel0DTa7seGeWw0Q1KZ67jHtvUbgLYH1bCWK3uo=
+github.com/confio/ics23/go v0.0.0-20200316200307-492bd3c6f3f6/go.mod h1:W1I3XC8d9N8OTu/ct5VJ84ylcOunZwMXsWkd27nvVts=
+github.com/confio/ics23/go v0.0.0-20200316202129-754fba6c5fdb h1:o8vRNhuwVbBqBgx2aXnGmss25I5d3pNFpQbjcU1wPL4=
+github.com/confio/ics23/go v0.0.0-20200316202129-754fba6c5fdb/go.mod h1:W1I3XC8d9N8OTu/ct5VJ84ylcOunZwMXsWkd27nvVts=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=


### PR DESCRIPTION
Depends on https://github.com/confio/ics23/pull/28

Updates to newest spec checks.

TODO: update dependency to tagged master before merge